### PR TITLE
fixed CLI args bug when binary file not provided

### DIFF
--- a/main.go
+++ b/main.go
@@ -352,7 +352,7 @@ func repl(c *cpu) {
 }
 
 func main() {
-	if len(os.Args) == 0 {
+	if len(os.Args) < 2 {
 		log.Fatal("Binary not provided")
 	}
 


### PR DESCRIPTION
Currently the go-amd64-emulator program gives an error if no file is given as a CLI arg

```
$ ls -l go-amd64-emulator 
-rwxr-xr-x. 1 root root 2593604 Nov 27 06:17 go-amd64-emulator
$ 
$ ./go-amd64-emulator 
panic: runtime error: index out of range [1] with length 1

goroutine 1 [running]:
main.main()
	/root/go-amd64-emulator/main.go:359 +0x3a3
$ 
```

Checking the code, I see some error handling code for the CLI arg
It checks to see if os.Args is `==` 0, this check is incorrect


```
$ 
$ sed -n '354,357p' main.go 
func main() {
	if len(os.Args) == 0 {
		log.Fatal("Binary not provided")
	}
$ 
```

Loading the program into a debugger to verify, we can clearly see that the value of os.Args is
`len: 1`  even when no CLI arg is provided, so the above check is not of much use

os.Args[0] = program name itself `go-amd64-emulator`
os.Args[1] = supposed to be the 1st CLI arg file provided to the program


```
$ dlv exec ./go-amd64-emulator 
Type 'help' for list of commands.
(dlv) b main.main
Breakpoint 1 set at 0x4bc8f8 for main.main() ./main.go:354
(dlv) continue
> main.main() ./main.go:354 (hits goroutine(1):1 total:1) (PC: 0x4bc8f8)
Warning: debugging optimized function
   349:				c.tick <- true
   350:			}
   351:		}
   352:	}
   353:	
=> 354:	func main() {
   355:		if len(os.Args) == 0 {
   356:			log.Fatal("Binary not provided")
   357:		}
   358:	
   359:		proc, err := readELF(os.Args[1], "main")
(dlv) p os.Args
[]string len: 1, cap: 1, [                         <<<<<<<<<<
	"./go-amd64-emulator",
]
(dlv) 
```

Following change seems to fix the issue

```
$ cp main.go main.go.BK
$ 
$ 
$ diff main.go main.go.BK 
355c355
< 	if len(os.Args) < 2 {
---
> 	if len(os.Args) == 0 {
$ 
$ go build
$ 
$ ./go-amd64-emulator 
2020/11/27 06:25:02 Binary not provided
$ 
```
